### PR TITLE
mapping derived errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ class MyMappingStrategy {
     if (errorMapper) {
       return errorMapper.mapError(err)
     }
+    
+    // alternatively, return a generic problem document
+    throw new Error('Could not map error')
   }
 }
 ```

--- a/src/DefaultErrorMapper.ts
+++ b/src/DefaultErrorMapper.ts
@@ -6,7 +6,7 @@ export class DefaultErrorMapper extends ErrorMapper {
   public constructor () {
     super(Error)
   }
-  public mapError (): ProblemDocument {
+  public mapError (): ProblemDocument | null {
     return StatusCodeErrorMapper.mapStatusCode(500)
   }
 }

--- a/src/DefaultErrorMapper.ts
+++ b/src/DefaultErrorMapper.ts
@@ -6,9 +6,7 @@ export class DefaultErrorMapper extends ErrorMapper {
   public constructor () {
     super(Error)
   }
-  public mapError (error: Error): ProblemDocument {
+  public mapError (): ProblemDocument {
     return StatusCodeErrorMapper.mapStatusCode(500)
   }
-
-  public error: string;
 }

--- a/src/DefaultErrorMapper.ts
+++ b/src/DefaultErrorMapper.ts
@@ -6,7 +6,9 @@ export class DefaultErrorMapper extends ErrorMapper {
   public constructor () {
     super(Error)
   }
-  public mapError (): ProblemDocument | null {
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public mapError (_: Error): ProblemDocument {
     return StatusCodeErrorMapper.mapStatusCode(500)
   }
 }

--- a/src/IErrorMapper.ts
+++ b/src/IErrorMapper.ts
@@ -3,12 +3,12 @@ import { ProblemDocument } from 'http-problem-details'
 type ErrorConstructor = new (...args: any[]) => Error
 export interface IErrorMapper {
   readonly error: string
-  mapError(error: Error): ProblemDocument
+  mapError(error: Error): ProblemDocument | null
 }
 
-export class ErrorMapper implements IErrorMapper {
+export abstract class ErrorMapper implements IErrorMapper {
   public readonly error: string;
-  public constructor (ErrorType?: ErrorConstructor) {
+  public constructor (ErrorType: ErrorConstructor) {
     if (this.constructor === ErrorMapper) {
       throw new TypeError('Can not construct abstract class.')
     }
@@ -17,13 +17,11 @@ export class ErrorMapper implements IErrorMapper {
       throw new TypeError(`Please implement abstract method 'mapError' in ${this.constructor.name}.`)
     }
 
-    if (ErrorType) {
-      this.error = ErrorType.name
-    }
+    this.error = ErrorType.name
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,handle-callback-err
-  public mapError (error: Error): ProblemDocument {
+  public mapError (error: Error): ProblemDocument | null {
     throw new TypeError(`Do not call abstract method 'mapError' from child.`)
   }
 }

--- a/src/IErrorMapper.ts
+++ b/src/IErrorMapper.ts
@@ -20,8 +20,5 @@ export abstract class ErrorMapper implements IErrorMapper {
     this.error = ErrorType.name
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,handle-callback-err
-  public mapError (error: Error): ProblemDocument | null {
-    throw new TypeError(`Do not call abstract method 'mapError' from child.`)
-  }
+  public abstract mapError (error: Error): ProblemDocument | null
 }

--- a/src/IErrorMapper.ts
+++ b/src/IErrorMapper.ts
@@ -3,7 +3,7 @@ import { ProblemDocument } from 'http-problem-details'
 type ErrorConstructor = new (...args: any[]) => Error
 export interface IErrorMapper {
   readonly error: string
-  mapError(error: Error): ProblemDocument | null
+  mapError(error: Error): ProblemDocument
 }
 
 export abstract class ErrorMapper implements IErrorMapper {
@@ -20,5 +20,5 @@ export abstract class ErrorMapper implements IErrorMapper {
     this.error = ErrorType.name
   }
 
-  public abstract mapError (error: Error): ProblemDocument | null
+  public abstract mapError (error: Error): ProblemDocument
 }

--- a/src/IMappingStrategy.ts
+++ b/src/IMappingStrategy.ts
@@ -18,8 +18,5 @@ export abstract class MappingStrategy implements IMappingStrategy {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,handle-callback-err
-  public map (error: Error): ProblemDocument {
-    throw new TypeError(`Do not call abstract method 'map' from child.`)
-  };
+  public abstract map (error: Error): ProblemDocument
 }

--- a/src/IMappingStrategy.ts
+++ b/src/IMappingStrategy.ts
@@ -3,7 +3,7 @@ import { ProblemDocument } from 'http-problem-details'
 
 export interface IMappingStrategy {
   registry: MapperRegistry
-  map(error: Error): ProblemDocument
+  map(error: Error): ProblemDocument | null
 }
 
 export abstract class MappingStrategy implements IMappingStrategy {
@@ -18,5 +18,5 @@ export abstract class MappingStrategy implements IMappingStrategy {
     }
   }
 
-  public abstract map (error: Error): ProblemDocument
+  public abstract map (error: Error): ProblemDocument | null
 }

--- a/src/IMappingStrategy.ts
+++ b/src/IMappingStrategy.ts
@@ -6,9 +6,9 @@ export interface IMappingStrategy {
   map(error: Error): ProblemDocument
 }
 
-export class MappingStrategy implements IMappingStrategy {
-  public registry: MapperRegistry;
-  public constructor () {
+export abstract class MappingStrategy implements IMappingStrategy {
+  public abstract registry: MapperRegistry;
+  protected constructor () {
     if (this.constructor === MappingStrategy) {
       throw new TypeError('Can not construct abstract class.')
     }

--- a/src/IMappingStrategy.ts
+++ b/src/IMappingStrategy.ts
@@ -3,7 +3,7 @@ import { ProblemDocument } from 'http-problem-details'
 
 export interface IMappingStrategy {
   registry: MapperRegistry
-  map(error: Error): ProblemDocument | null
+  map(error: Error): ProblemDocument
 }
 
 export abstract class MappingStrategy implements IMappingStrategy {
@@ -18,5 +18,5 @@ export abstract class MappingStrategy implements IMappingStrategy {
     }
   }
 
-  public abstract map (error: Error): ProblemDocument | null
+  public abstract map (error: Error): ProblemDocument
 }

--- a/src/MapperRegistry.ts
+++ b/src/MapperRegistry.ts
@@ -26,6 +26,20 @@ export class MapperRegistry {
   }
 
   public getMapper (error: Error): IErrorMapper {
-    return this.mappers.find((mapper): boolean => mapper.error === error.constructor.name)
+    let constructor = error.constructor
+    let proto = Object.getPrototypeOf(error)
+    let mapper
+
+    while (constructor.name !== 'Object') {
+      mapper = this.mappers.find((mapper): boolean => mapper.error === constructor.name)
+      if (mapper) {
+        break
+      } else {
+        proto = Object.getPrototypeOf(proto)
+        constructor = proto.constructor
+      }
+    }
+
+    return mapper
   }
 }

--- a/src/MapperRegistry.ts
+++ b/src/MapperRegistry.ts
@@ -1,8 +1,8 @@
 import { IErrorMapper } from './IErrorMapper'
 import { DefaultErrorMapper } from './DefaultErrorMapper'
 
-class MapperRegistryOptions {
-  public useDefaultErrorMapper: boolean;
+interface MapperRegistryOptions {
+  useDefaultErrorMapper: boolean
 }
 
 export class MapperRegistry {
@@ -25,7 +25,7 @@ export class MapperRegistry {
     return this
   }
 
-  public getMapper (error: Error): IErrorMapper {
+  public getMapper (error: Error): IErrorMapper | null {
     let constructor = error.constructor
     let proto = Object.getPrototypeOf(error)
     let mapper
@@ -40,6 +40,6 @@ export class MapperRegistry {
       }
     }
 
-    return mapper
+    return mapper || null
   }
 }

--- a/src/StatusCodeErrorMapper.ts
+++ b/src/StatusCodeErrorMapper.ts
@@ -3,7 +3,7 @@ import { ErrorStatusCodes } from './ErrorStatusCodes'
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class StatusCodeErrorMapper {
-  public static mapStatusCode (statusCode: number): ProblemDocument | null {
+  public static mapStatusCode (statusCode: number): ProblemDocument {
     if (!ErrorStatusCodes.includes(statusCode)) {
       throw new Error(`${statusCode} is not an error Status Code`)
     }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": ["off"]
+  }
+}

--- a/test/MapperRegistryTest.ts
+++ b/test/MapperRegistryTest.ts
@@ -31,7 +31,7 @@ describe('MapperRegistry', (): void => {
       .registerMapper(new FooErrorMapper())
       .registerMapper(new BarErrorMapper())
 
-    const mapper = registry.getMapper(new FooError())
+    const mapper = registry.getMapper(new FooError())!
 
     mapper.should.be.instanceOf(FooErrorMapper)
   })
@@ -40,7 +40,7 @@ describe('MapperRegistry', (): void => {
     const registry = new MapperRegistry()
       .registerMapper(new FooErrorMapper())
 
-    const mapper = registry.getMapper(new ChildFooError())
+    const mapper = registry.getMapper(new ChildFooError())!
 
     mapper.should.be.instanceOf(FooErrorMapper)
   })
@@ -49,7 +49,7 @@ describe('MapperRegistry', (): void => {
     const registry = new MapperRegistry()
       .registerMapper(new BarErrorMapper())
 
-    const mapper = registry.getMapper(new ChildFooError())
+    const mapper = registry.getMapper(new ChildFooError())!
 
     mapper.should.be.instanceOf(DefaultErrorMapper)
   })

--- a/test/MapperRegistryTest.ts
+++ b/test/MapperRegistryTest.ts
@@ -1,9 +1,10 @@
 import 'should'
-import { ErrorMapper, MapperRegistry } from '../src'
+import { DefaultErrorMapper, ErrorMapper, MapperRegistry } from '../src'
 import { ProblemDocument } from 'http-problem-details'
 
 class FooError extends Error {}
 class BarError extends Error {}
+class ChildFooError extends FooError {}
 
 class FooErrorMapper extends ErrorMapper {
   public constructor () {
@@ -33,5 +34,23 @@ describe('MapperRegistry', (): void => {
     const mapper = registry.getMapper(new FooError())
 
     mapper.should.be.instanceOf(FooErrorMapper)
+  })
+
+  it('returns a mapper for a matched superclass', (): void => {
+    const registry = new MapperRegistry()
+      .registerMapper(new FooErrorMapper())
+
+    const mapper = registry.getMapper(new ChildFooError())
+
+    mapper.should.be.instanceOf(FooErrorMapper)
+  })
+
+  it('returns default mapper unmapped class', (): void => {
+    const registry = new MapperRegistry()
+      .registerMapper(new BarErrorMapper())
+
+    const mapper = registry.getMapper(new ChildFooError())
+
+    mapper.should.be.instanceOf(DefaultErrorMapper)
   })
 })

--- a/test/mappertest.ts
+++ b/test/mappertest.ts
@@ -1,16 +1,16 @@
 import 'should'
-import { DefaultErrorMapper, ErrorMapper } from '../src'
+import { DefaultErrorMapper, ErrorMapper, IErrorMapper } from '../src'
 import { ProblemDocument } from 'http-problem-details'
 
 describe('Error Mappers', (): void => {
   describe('When mapping an Error', (): void => {
     it('should create Internal Server Error Problem Document', (done): void => {
-      const mapper = new DefaultErrorMapper()
-      const problem = mapper.mapError(new Error(`There's a problem...`))
+      const mapper: IErrorMapper = new DefaultErrorMapper()
+      const problem = mapper.mapError(new Error(`There's a problem...`))!
 
       problem.status.should.equal(500)
       problem.title.should.equal('Internal Server Error')
-      problem.type.should.equal('about:blank')
+      problem.should.have.property('type', 'about:blank')
       return done()
     })
   })

--- a/test/mappertest.ts
+++ b/test/mappertest.ts
@@ -1,12 +1,12 @@
 import 'should'
-import { DefaultErrorMapper, ErrorMapper, IErrorMapper } from '../src'
+import { DefaultErrorMapper, ErrorMapper } from '../src'
 import { ProblemDocument } from 'http-problem-details'
 
 describe('Error Mappers', (): void => {
   describe('When mapping an Error', (): void => {
     it('should create Internal Server Error Problem Document', (done): void => {
-      const mapper: IErrorMapper = new DefaultErrorMapper()
-      const problem = mapper.mapError(new Error(`There's a problem...`))!
+      const mapper = new DefaultErrorMapper()
+      const problem = mapper.mapError(new Error(`There's a problem...`))
 
       problem.status.should.equal(500)
       problem.title.should.equal('Internal Server Error')

--- a/test/statuscodemappertests.ts
+++ b/test/statuscodemappertests.ts
@@ -3,7 +3,7 @@ import 'should'
 
 describe('error status code mapper', (): void => {
   describe('When mapping 400 status code', (): void => {
-    const document = StatusCodeErrorMapper.mapStatusCode(400)!
+    const document = StatusCodeErrorMapper.mapStatusCode(400)
 
     it('should create Bad Request Problem with status code 400', (done): void => {
       document.status.should.equal(400)

--- a/test/statuscodemappertests.ts
+++ b/test/statuscodemappertests.ts
@@ -3,7 +3,7 @@ import 'should'
 
 describe('error status code mapper', (): void => {
   describe('When mapping 400 status code', (): void => {
-    const document = StatusCodeErrorMapper.mapStatusCode(400)
+    const document = StatusCodeErrorMapper.mapStatusCode(400)!
 
     it('should create Bad Request Problem with status code 400', (done): void => {
       document.status.should.equal(400)
@@ -11,7 +11,7 @@ describe('error status code mapper', (): void => {
     })
 
     it('should create Bad Request Problem with about:blank type', (done): void => {
-      document.type.should.equal('about:blank')
+      document.should.have.property('type', 'about:blank')
       return done()
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
+    "strict": true,
     "paths": {
       "*": [
         "node_modules/*",


### PR DESCRIPTION
Related to related to PDMLab/express-http-problem-details#12, I go up the prototype chain to find mappers of superclass. This way any error will eventually be mapped by the default mapper.