### PR TITLE
revert: have IMappingStrategy allow null return value after all

### DIFF
--- a/src/IMappingStrategy.ts
+++ b/src/IMappingStrategy.ts
@@ -3,7 +3,7 @@ import { ProblemDocument } from 'http-problem-details'
 
 export interface IMappingStrategy {
   registry: MapperRegistry
-  map(error: Error): ProblemDocument
+  map(error: Error): ProblemDocument | null
 }
 
 export abstract class MappingStrategy implements IMappingStrategy {
@@ -18,5 +18,5 @@ export abstract class MappingStrategy implements IMappingStrategy {
     }
   }
 
-  public abstract map (error: Error): ProblemDocument
+  public abstract map (error: Error): ProblemDocument | null
 }


### PR DESCRIPTION
I thought again about the return value of `IMappingStrategy#map` and concluded that it should in fact allow `null` return value and never really throw intentionally.

Why? Because we have to code against the possibility that the registry fails to provide a mapper anyway. That is always a possibility in a language such as TS/JS.

In such case it should be up to the actual program to handle the error in its own standard way (in case of express see [this change](https://github.com/PDMLab/express-http-problem-details/pull/14/files#diff-1f7d666e4e88d22e8f3246a36fc060eeR20)).