### PR TITLE
fix: try to map common status code properties from Error instances

### DIFF
--- a/src/DefaultErrorMapper.ts
+++ b/src/DefaultErrorMapper.ts
@@ -2,13 +2,17 @@ import { ErrorMapper } from './IErrorMapper'
 import { ProblemDocument } from 'http-problem-details'
 import { StatusCodeErrorMapper } from './StatusCodeErrorMapper'
 
+type CommonError = Error & {
+  status?: number
+  code?: number
+}
+
 export class DefaultErrorMapper extends ErrorMapper {
   public constructor () {
     super(Error)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public mapError (_: Error): ProblemDocument {
-    return StatusCodeErrorMapper.mapStatusCode(500)
+  public mapError (error: CommonError): ProblemDocument {
+    return StatusCodeErrorMapper.mapStatusCode(error.status || error.code || 500)
   }
 }


### PR DESCRIPTION
It has been suggested to me that instances of `Error` in express context, such as produced by the very popular [`http-errors` package](https://www.npmjs.com/package/http-errors), will have a `status` property. It could be used to create the fallback problem document with accurate status code.

I found that a `code` property is also used so the default mapper shall also check that before going for the generic `500`.